### PR TITLE
Feature/add cdb pvc

### DIFF
--- a/api/v1alpha1/nso_types.go
+++ b/api/v1alpha1/nso_types.go
@@ -67,6 +67,9 @@ type NSOSpec struct {
 	// +kubebuilder:validation:Optional
 	// NSO volumes.
 	Volumes []corev1.Volume `json:"volumes"`
+
+	// +kubebuilder:validation:Optional
+	CDBStorageSize string `json:"cdbStorageSize,omitempty"`
 }
 
 // Credentials for admin user.

--- a/api/v1alpha1/nso_types.go
+++ b/api/v1alpha1/nso_types.go
@@ -69,6 +69,7 @@ type NSOSpec struct {
 	Volumes []corev1.Volume `json:"volumes"`
 
 	// +kubebuilder:validation:Optional
+	// Storage size for the CDB (Configuration Database) persistent volume. Default: 5Gi if not specified.
 	CDBStorageSize string `json:"cdbStorageSize,omitempty"`
 }
 

--- a/internal/controller/nso_controller.go
+++ b/internal/controller/nso_controller.go
@@ -72,7 +72,7 @@ func (r *NSOReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	cdbPVC := r.newCDBPersistentVolumeClaim(ctx, nso)
 	requeue, err := ensureObjectExists(ctx, r.Client, cdbPVC)
 	if err != nil || requeue {
-		return ctrl.Result{Requeue: requeue}, err 
+		return ctrl.Result{Requeue: requeue}, err
 	}
 
 	// Create NSO Service

--- a/internal/controller/nso_controller.go
+++ b/internal/controller/nso_controller.go
@@ -69,9 +69,15 @@ func (r *NSOReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 		return ctrl.Result{}, err
 	}
 
+	cdbPVC := r.newCDBPersistentVolumeClaim(ctx, nso)
+	requeue, err := ensureObjectExists(ctx, r.Client, cdbPVC)
+	if err != nil || requeue {
+		return ctrl.Result{Requeue: requeue}, err 
+	}
+
 	// Create NSO Service
 	service := r.newService(ctx, nso)
-	requeue, err := ensureObjectExists(ctx, r.Client, service)
+	requeue, err = ensureObjectExists(ctx, r.Client, service)
 	if err != nil || requeue {
 		return ctrl.Result{Requeue: requeue}, nil
 	}

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -32,6 +32,7 @@ import (
 )
 
 func (r *NSOReconciler) newCDBPersistentVolumeClaim(ctx context.Context, nso *nsov1alpha1.NSO) *corev1.PersistentVolumeClaim {
+	log := logf.FromContext(ctx)
 	size := "5Gi"
 	if nso.Spec.CDBStorageSize != "" {
 		size = nso.Spec.CDBStorageSize
@@ -39,23 +40,28 @@ func (r *NSOReconciler) newCDBPersistentVolumeClaim(ctx context.Context, nso *ns
 
 	pvc := &corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:	fmt.Sprintf("%s-cdb", nso.Name),
-			Namespace : nso.Namespace,
+			Name:      fmt.Sprintf("%s-cdb", nso.Name),
+			Namespace: nso.Namespace,
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes: []corev1.PersistentVolumeAccessMode{
 				corev1.ReadWriteOnce,
 			},
-			Resources : corev1.VolumeResourceRequirements{
+			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
 					corev1.ResourceStorage: resource.MustParse(size),
 				},
 			},
 		},
 	}
-	controllerutil.SetControllerReference(nso, pvc, r.Scheme)
+	err := controllerutil.SetControllerReference(nso, pvc, r.Scheme)
+	if err != nil {
+		log.Error(err, "Failed to set controller reference for CDB PVC")
+		return &corev1.PersistentVolumeClaim{}
+	}
 	return pvc
 }
+
 // Create a new Headless Service for NSO StatefulSet
 func (r *NSOReconciler) newService(ctx context.Context, nso *nsov1alpha1.NSO) *corev1.Service {
 	log := logf.FromContext(ctx)

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -33,9 +33,9 @@ import (
 
 func (r *NSOReconciler) newCDBPersistentVolumeClaim(ctx context.Context, nso *nsov1alpha1.NSO) *corev1.PersistentVolumeClaim {
 	log := logf.FromContext(ctx)
-	size := "5Gi"
+	defaultSize := "5Gi"
 	if nso.Spec.CDBStorageSize != "" {
-		size = nso.Spec.CDBStorageSize
+		defaultSize = nso.Spec.CDBStorageSize
 	}
 
 	pvc := &corev1.PersistentVolumeClaim{
@@ -49,7 +49,7 @@ func (r *NSOReconciler) newCDBPersistentVolumeClaim(ctx context.Context, nso *ns
 			},
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
-					corev1.ResourceStorage: resource.MustParse(size),
+					corev1.ResourceStorage: resource.MustParse(defaultSize),
 				},
 			},
 		},

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -31,6 +31,31 @@ import (
 	nsov1alpha1 "github.com/carlosgrillet/nso-operator/api/v1alpha1"
 )
 
+func (r *NSOReconciler) newCDBPersistentVolumeClaim(ctx context.Context, nso *nsov1alpha1.NSO) *corev1.PersistentVolumeClaim {
+	size := "5Gi"
+	if nso.Spec.CDBStorageSize != "" {
+		size = nso.Spec.CDBStorageSize
+	}
+
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:	fmt.Sprintf("%s-cdb", nso.Name),
+			Namespace : nso.Namespace,
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{
+				corev1.ReadWriteOnce,
+			},
+			Resources : corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceStorage: resource.MustParse(size),
+				},
+			},
+		},
+	}
+	controllerutil.SetControllerReference(nso, pvc, r.Scheme)
+	return pvc
+}
 // Create a new Headless Service for NSO StatefulSet
 func (r *NSOReconciler) newService(ctx context.Context, nso *nsov1alpha1.NSO) *corev1.Service {
 	log := logf.FromContext(ctx)
@@ -104,6 +129,9 @@ func (r *NSOReconciler) newStatefulSet(ctx context.Context, nso *nsov1alpha1.NSO
 							Name:      "ncs-config",
 							MountPath: "/etc/ncs/ncs.conf",
 							SubPath:   "ncs.conf",
+						}, {
+							Name:      "cdb-storage",
+							MountPath: "/nso/run/cdb",
 						}}, nso.Spec.VolumeMounts...),
 					}},
 					Volumes: append([]corev1.Volume{{
@@ -118,6 +146,13 @@ func (r *NSOReconciler) newStatefulSet(ctx context.Context, nso *nsov1alpha1.NSO
 									Path: "ncs.conf",
 									Mode: &ncsConfigFileMode,
 								}},
+							},
+						},
+					}, {
+						Name: "cdb-storage",
+						VolumeSource: corev1.VolumeSource{
+							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+								ClaimName: fmt.Sprintf("%s-cdb", nso.Name),
 							},
 						},
 					}}, nso.Spec.Volumes...),

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -186,14 +186,16 @@ var _ = Describe("Resource Creation Functions", func() {
 
 				// Check volume mounts
 				volumeMounts := container.VolumeMounts
-				Expect(volumeMounts).To(HaveLen(1))
+				Expect(volumeMounts).To(HaveLen(2))
 				Expect(volumeMounts[0].Name).To(Equal("ncs-config"))
 				Expect(volumeMounts[0].MountPath).To(Equal("/etc/ncs/ncs.conf"))
 				Expect(volumeMounts[0].SubPath).To(Equal("ncs.conf"))
+				Expect(volumeMounts[1].Name).To(Equal("cdb-storage"))
+				Expect(volumeMounts[1].MountPath).To(Equal("/nso/run/cdb"))
 
 				// Check volumes
 				volumes := podTemplate.Spec.Volumes
-				Expect(volumes).To(HaveLen(1))
+				Expect(volumes).To(HaveLen(2))
 				volume := volumes[0]
 				Expect(volume.Name).To(Equal("ncs-config"))
 				Expect(volume.ConfigMap).NotTo(BeNil())
@@ -203,8 +205,107 @@ var _ = Describe("Resource Creation Functions", func() {
 				Expect(volume.ConfigMap.Items[0].Path).To(Equal("ncs.conf"))
 				Expect(*volume.ConfigMap.Items[0].Mode).To(Equal(int32(0600)))
 
+				cdbVolume := volumes[1]
+				Expect(cdbVolume.Name).To(Equal("cdb-storage"))
+				Expect(cdbVolume.PersistentVolumeClaim).NotTo(BeNil())
+				Expect(cdbVolume.PersistentVolumeClaim.ClaimName).To(Equal("test-nso-statefulset-cdb"))
+
 				// Clean up
 				err = k8sClient.Delete(ctx, testNSO2)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Describe("newCDBPersistentVolumeClaim", func() {
+			It("should create CDB PVC with default size", func() {
+				// Create a separate NSO for this test
+				testNSO3 := &orchestrationciscocomv1alpha1.NSO{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-nso-cdb",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.NSOSpec{
+						Image:       "test-nso:latest",
+						ServiceName: "test-nso-service",
+						Replicas:    1,
+						LabelSelector: map[string]string{
+							"app": "nso-test",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name: "http",
+								Port: 8080,
+							},
+							{
+								Name: "https",
+								Port: 8888,
+							},
+						},
+						NsoConfigRef: "test-nso-config",
+						AdminCredentials: orchestrationciscocomv1alpha1.Credentials{
+							Username:          "admin",
+							PasswordSecretRef: "test-admin-secret",
+						},
+					},
+				}
+
+				err := k8sClient.Create(ctx, testNSO3)
+				Expect(err).NotTo(HaveOccurred())
+
+				pvc := nsoReconciler.newCDBPersistentVolumeClaim(ctx, testNSO3)
+
+				Expect(pvc.Name).To(Equal("test-nso-cdb-cdb"))
+				Expect(pvc.Namespace).To(Equal("default"))
+				Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("5Gi")))
+				Expect(pvc.Spec.AccessModes).To(ContainElement(corev1.ReadWriteOnce))
+
+				// Clean up
+				err = k8sClient.Delete(ctx, testNSO3)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should create CDB PVC with custom size", func() {
+				// Create NSO with custom CDB size
+				testNSO4 := &orchestrationciscocomv1alpha1.NSO{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-nso-cdb-custom",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.NSOSpec{
+						Image:          "test-nso:latest",
+						ServiceName:    "test-nso-service",
+						Replicas:       1,
+						CDBStorageSize: "10Gi",
+						LabelSelector: map[string]string{
+							"app": "nso-test",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name: "http",
+								Port: 8080,
+							},
+							{
+								Name: "https",
+								Port: 8888,
+							},
+						},
+						NsoConfigRef: "test-nso-config",
+						AdminCredentials: orchestrationciscocomv1alpha1.Credentials{
+							Username:          "admin",
+							PasswordSecretRef: "test-admin-secret",
+						},
+					},
+				}
+
+				err := k8sClient.Create(ctx, testNSO4)
+				Expect(err).NotTo(HaveOccurred())
+
+				pvc := nsoReconciler.newCDBPersistentVolumeClaim(ctx, testNSO4)
+
+				Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("10Gi")))
+
+				// Clean up
+				err = k8sClient.Delete(ctx, testNSO4)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})


### PR DESCRIPTION
## 🌸 What’s this PR about?
<!-- Short & sweet description of what this PR does -->
New Persistent Volume was added to hold NSO CDB with the Operator. This was achieved by adding a PVC so NSO Controller can take it. 

- ✨ Feature / Fix / Refactor: Feature
- 🎯 Why it exists: NSO CDB needs to be persistent
- 🧩 Related ticket / issue:

---

## 🛠️ What changed?
<!-- Bullet list of main changes -->

- 🐣 Added: 
- 🔧 Updated: Stateful Set definition to add Persistent Volume Claim for NSO CDB
- 🧹 Cleaned up:
- 💥 Breaking changes (if any):

---

## 🧪 How was this tested?

- [X ] Unit tests
- [ ] Integration tests
- [ X] Manual testing
- [ ] Not tested (please explain 😇)

**Test notes:**

Unit Tests results:

```
test $(go list ./... | grep -v /e2e) -coverprofile cover.out
        github.com/carlosgrillet/nso-operator/api/v1alpha1              coverage: 0.0% of statements
        github.com/carlosgrillet/nso-operator/cmd               coverage: 0.0% of statements
ok      github.com/carlosgrillet/nso-operator/internal/controller       10.585s coverage: 63.6% of stat
```

Manual Tests Results:

```
admin@ncs(config)# nacm groups group operator user-name casbarre
admin@ncs(config-group-operator)# commit dry-run outformat xml 
result-xml {
    local-node {
        data <nacm xmlns="urn:ietf:params:xml:ns:yang:ietf-netconf-acm">
               <groups>
                 <group>
                   <name>operator</name>
                   <user-name>casbarre</user-name>
                 </group>
               </groups>
             </nacm>
    }
}
admin@ncs(config-group-operator)# commit
Commit complete.
admin@ncs(config-group-operator)# exit
admin@ncs(config)# exit
admin@ncs# exit
[root@nso-sample-0 /]# exit
exit
±  kubectl delete pod nso-sample-0
pod "nso-sample-0" deleted
  feature/add-cdb-PVC ±  kubectl wait --for=condition=ready pod nso-sample-0 --timeout=300s
pod/nso-sample-0 condition met
  feature/add-cdb-PVC ±  kubectl exec -it nso-sample-0 -- ncs_cli -C -u admin

admin connected from 127.0.0.1 using console on nso-sample-0     
admin@ncs# show running-config nacm groups 
nacm groups group ncsadmin
 user-name [ admin private ]
!
nacm groups group ncsoper
 user-name [ public ]
!
nacm groups group operator
 user-name [ casbarre ]
!
admin@ncs# exit

```
