### PR TITLE
Feature/enabling git clone ssh

### DIFF
--- a/config/samples/ssh-key-secret-sample.yaml
+++ b/config/samples/ssh-key-secret-sample.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ssh-key
+  namespace: default
+type: Opaque
+data:
+  id_rsa: <base64-encoded-PEM-private-key-here>

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -194,12 +194,18 @@ func updatePackageBundlePhase(ctx context.Context, c client.Client, packageBundl
 			return nil
 		}
 
+		// Check if phase is actually changing (for LastTransitionTime)
+		phaseChanged := latest.Status.Phase != newPhase
+
 		// Update status fields
-		now := metav1.NewTime(time.Now())
 		latest.Status.Phase = newPhase
 		latest.Status.Message = message
 		latest.Status.JobName = jobName
-		latest.Status.LastTransitionTime = &now
+
+		if phaseChanged {
+			now := metav1.NewTime(time.Now())
+			latest.Status.LastTransitionTime = &now
+		}
 
 		// Update the status subresource
 		return c.Status().Update(ctx, latest)

--- a/internal/controller/packagebundle_controller.go
+++ b/internal/controller/packagebundle_controller.go
@@ -247,7 +247,6 @@ func (r *PackageBundleReconciler) unmountPVCFromNSO(ctx context.Context, package
 	log.Info("Removing PVC volume from NSO instance", "nso", nso.Name, "volume", volumeName)
 
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		
 		latestNSO := &nsov1alpha1.NSO{}
 		if err := r.Get(ctx, client.ObjectKey{
 			Name:      packageBundle.Spec.TargetName,

--- a/internal/controller/packagebundle_controller.go
+++ b/internal/controller/packagebundle_controller.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	nsov1alpha1 "github.com/carlosgrillet/nso-operator/api/v1alpha1"
@@ -53,6 +54,9 @@ const (
 	downloadJobNameFmt   = "download-%s"
 	jobVolumeName        = "package-storage"
 	jobVolumeMountPath   = "/repo"
+
+	// Finalizer for cleanup
+	packageBundleFinalizer = "packagebundle.orchestration.cisco.com/finalizer"
 )
 
 // Sentinel errors for control flow
@@ -89,7 +93,6 @@ type PackageBundleReconciler struct {
 func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := logf.FromContext(ctx)
 
-	// Fetch the PackageBundle instance
 	packageBundle := &nsov1alpha1.PackageBundle{}
 	err := r.Get(ctx, req.NamespacedName, packageBundle)
 	if err != nil {
@@ -101,7 +104,36 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, err
 	}
 
-	// Set initial status if not set
+	if packageBundle.DeletionTimestamp != nil {
+		if controllerutil.ContainsFinalizer(packageBundle, packageBundleFinalizer) {
+
+			log.Info("PackageBundle is being deleted, cleaning up")
+
+			if err := r.unmountPVCFromNSO(ctx, packageBundle); err != nil {
+				log.Error(err, "Failed to unmount PVC during deletion")
+				return ctrl.Result{}, err
+			}
+
+			controllerutil.RemoveFinalizer(packageBundle, packageBundleFinalizer)
+			if err := r.Update(ctx, packageBundle); err != nil {
+				log.Error(err, "Failed to remove finalizer")
+				return ctrl.Result{}, err
+			}
+			log.Info("Finalizer removed, PackageBundle can now be deleted")
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(packageBundle, packageBundleFinalizer) {
+		controllerutil.AddFinalizer(packageBundle, packageBundleFinalizer)
+		if err := r.Update(ctx, packageBundle); err != nil {
+			log.Error(err, "Failed to add finalizer")
+			return ctrl.Result{}, err
+		}
+		log.Info("Finalizer added to PackageBundle")
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	if packageBundle.Status.Phase == "" {
 		if err := updatePackageBundlePhase(ctx, r.Client, packageBundle, nsov1alpha1.PackageBundlePhasePending, "PackageBundle created", ""); err != nil {
 			log.Error(err, "Failed to set initial status")
@@ -114,7 +146,6 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 
-	// If downloaded OR loading, proceed to mount the PVC and reload packages
 	if packageBundle.Status.Phase == nsov1alpha1.PackageBundlePhaseDownloaded ||
 		packageBundle.Status.Phase == nsov1alpha1.PackageBundlePhaseLoading {
 		if err := r.mountPVCToNSO(ctx, packageBundle); err != nil {
@@ -123,7 +154,6 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				log.Info("NSO pod not ready, will retry", "error", err)
 				return ctrl.Result{RequeueAfter: requeueIntervalMountRetry}, nil
 			}
-			// Actual errors should be returned
 			log.Error(err, "Failed to mount PVC or reload packages in NSO instance")
 			return ctrl.Result{}, err
 		}
@@ -181,6 +211,78 @@ func (r *PackageBundleReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 	// If job succeeded, the phase will be Downloaded and on next reconcile the PVC will be mounted
 	return ctrl.Result{}, nil
+}
+
+func (r *PackageBundleReconciler) unmountPVCFromNSO(ctx context.Context, packageBundle *nsov1alpha1.PackageBundle) error {
+	log := logf.FromContext(ctx)
+
+	nso := &nsov1alpha1.NSO{}
+	err := r.Get(ctx, client.ObjectKey{
+		Name:      packageBundle.Spec.TargetName,
+		Namespace: packageBundle.Namespace,
+	}, nso)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Info("NSO instance not found, nothing to unmount", "targetName", packageBundle.Spec.TargetName)
+			return nil
+		}
+		return err
+	}
+
+	volumeName := generatePackageVolumeName(packageBundle.Name)
+
+	volumeExists := false
+	for _, vol := range nso.Spec.Volumes {
+		if vol.Name == volumeName {
+			volumeExists = true
+			break
+		}
+	}
+
+	if !volumeExists {
+		log.Info("Volume not mounted, nothing to unmount", "volume", volumeName)
+		return nil
+	}
+
+	log.Info("Removing PVC volume from NSO instance", "nso", nso.Name, "volume", volumeName)
+
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		
+		latestNSO := &nsov1alpha1.NSO{}
+		if err := r.Get(ctx, client.ObjectKey{
+			Name:      packageBundle.Spec.TargetName,
+			Namespace: packageBundle.Namespace,
+		}, latestNSO); err != nil {
+			return err
+		}
+
+		newVolumes := []corev1.Volume{}
+		for _, vol := range latestNSO.Spec.Volumes {
+			if vol.Name != volumeName {
+				newVolumes = append(newVolumes, vol)
+			}
+		}
+		latestNSO.Spec.Volumes = newVolumes
+
+		newVolumeMounts := []corev1.VolumeMount{}
+		for _, vm := range latestNSO.Spec.VolumeMounts {
+			if vm.Name != volumeName {
+				newVolumeMounts = append(newVolumeMounts, vm)
+			}
+		}
+		latestNSO.Spec.VolumeMounts = newVolumeMounts
+
+		// Update the NSO instance
+		return r.Update(ctx, latestNSO)
+	})
+
+	if err != nil {
+		log.Error(err, "Failed to update NSO instance to remove PVC mount")
+		return err
+	}
+
+	log.Info("Successfully unmounted PVC from NSO instance", "nso", nso.Name)
+	return nil
 }
 
 // mountPVCToNSO mounts the PVC to the NSO instance specified in targetName

--- a/internal/controller/packagebundle_controller_test.go
+++ b/internal/controller/packagebundle_controller_test.go
@@ -41,7 +41,7 @@ var _ = Describe("PackageBundle Controller", func() {
 
 		typeNamespacedName := types.NamespacedName{
 			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
+			Namespace: "default",
 		}
 		packagebundle := &orchestrationciscocomv1alpha1.PackageBundle{}
 
@@ -84,13 +84,19 @@ var _ = Describe("PackageBundle Controller", func() {
 			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
 		})
 		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
+			By("Reconciling the created resource (adds finalizer)")
 			controllerReconciler := &PackageBundleReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: typeNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconciling again to set status")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -103,36 +109,110 @@ var _ = Describe("PackageBundle Controller", func() {
 		})
 
 		It("should create PVC and Job resources", func() {
-			By("Reconciling the resource")
+			// Create a unique PackageBundle for this test to avoid conflicts
+			uniquePB := &orchestrationciscocomv1alpha1.PackageBundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-resource-pvc-job",
+					Namespace: "default",
+				},
+				Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+					TargetName:  "test-nso",
+					StorageSize: "1Gi",
+					Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+					Source: orchestrationciscocomv1alpha1.PackageSource{
+						Url:  "https://github.com/example/test-repo.git",
+						Path: "packages",
+					},
+					Config: orchestrationciscocomv1alpha1.PackageConfig{
+						Download: orchestrationciscocomv1alpha1.ContainerParams{
+							Image: "alpine/git",
+						},
+						Build: orchestrationciscocomv1alpha1.ContainerParams{
+							Image: "carlosgrillet/cisco-nso:6.1.19-build",
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, uniquePB)
+			Expect(err).NotTo(HaveOccurred())
+
+			uniqueNamespacedName := types.NamespacedName{
+				Name:      uniquePB.Name,
+				Namespace: uniquePB.Namespace,
+			}
+
+			By("Reconciling multiple times to create resources")
 			controllerReconciler := &PackageBundleReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
-			Expect(err).NotTo(HaveOccurred())
-
 			By("Verifying PVC was created")
-			pvcName := resourceName + "-test-nso"
+			pvcName := uniquePB.Name + "-test-nso"
 			pvc := &corev1.PersistentVolumeClaim{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: "default"}, pvc)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				// Keep reconciling to progress through states
+				_, _ = controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: uniqueNamespacedName,
+				})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: pvcName, Namespace: "default"}, pvc)
+			}, time.Second*10, time.Millisecond*500).Should(Succeed())
 			Expect(pvc.Spec.Resources.Requests[corev1.ResourceStorage]).To(Equal(resource.MustParse("1Gi")))
 
 			By("Verifying Job was created")
-			jobName := "download-" + resourceName
+			jobName := "download-" + uniquePB.Name
 			job := &batchv1.Job{}
-			err = k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: "default"}, job)
-			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() error {
+				// Keep reconciling to progress through states
+				_, _ = controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: uniqueNamespacedName,
+				})
+				return k8sClient.Get(ctx, types.NamespacedName{Name: jobName, Namespace: "default"}, job)
+			}, time.Second*10, time.Millisecond*500).Should(Succeed())
 			Expect(job.Spec.Template.Spec.InitContainers[0].Image).To(Equal("alpine/git"))
 			Expect(job.Spec.Template.Spec.Containers[0].Image).To(Equal("carlosgrillet/cisco-nso:6.1.19-build"))
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, uniquePB)).To(Succeed())
 		})
 
 		It("should update status based on Job completion", func() {
+			// Create a unique PackageBundle for this test
+			uniquePB := &orchestrationciscocomv1alpha1.PackageBundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-resource-job-complete",
+					Namespace: "default",
+				},
+				Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+					TargetName:  "test-nso",
+					StorageSize: "1Gi",
+					Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+					Source: orchestrationciscocomv1alpha1.PackageSource{
+						Url:  "https://github.com/example/test-repo.git",
+						Path: "packages",
+					},
+					Config: orchestrationciscocomv1alpha1.PackageConfig{
+						Download: orchestrationciscocomv1alpha1.ContainerParams{
+							Image: "alpine/git",
+						},
+						Build: orchestrationciscocomv1alpha1.ContainerParams{
+							Image: "carlosgrillet/cisco-nso:6.1.19-build",
+						},
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, uniquePB)
+			Expect(err).NotTo(HaveOccurred())
+
+			uniqueNamespacedName := types.NamespacedName{
+				Name:      uniquePB.Name,
+				Namespace: uniquePB.Namespace,
+			}
+
 			By("Creating a completed Job manually to simulate completion")
-			jobName := "download-" + resourceName
+			jobName := "download-" + uniquePB.Name
 			completedJob := &batchv1.Job{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      jobName,
@@ -158,10 +238,8 @@ var _ = Describe("PackageBundle Controller", func() {
 				},
 			}
 
-			err := k8sClient.Create(ctx, completedJob)
-			if err != nil && !errors.IsAlreadyExists(err) {
-				Expect(err).NotTo(HaveOccurred())
-			}
+			err = k8sClient.Create(ctx, completedJob)
+			Expect(err).NotTo(HaveOccurred())
 
 			By("Updating job status to completed")
 			now := metav1.Now()
@@ -183,26 +261,40 @@ var _ = Describe("PackageBundle Controller", func() {
 			err = k8sClient.Status().Update(ctx, completedJob)
 			Expect(err).NotTo(HaveOccurred())
 
-			By("Reconciling again to check Job status")
+			By("Reconciling to check Job status (adds finalizer first)")
 			controllerReconciler := &PackageBundleReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
 
 			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
+				NamespacedName: uniqueNamespacedName,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Reconciling again to process job status")
+			_, err = controllerReconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: uniqueNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Verifying PackageBundle status was updated to Downloaded")
 			Eventually(func() orchestrationciscocomv1alpha1.PackageBundlePhase {
 				updatedPackageBundle := &orchestrationciscocomv1alpha1.PackageBundle{}
-				err := k8sClient.Get(ctx, typeNamespacedName, updatedPackageBundle)
+				err := k8sClient.Get(ctx, uniqueNamespacedName, updatedPackageBundle)
 				if err != nil {
 					return ""
 				}
+				// Keep reconciling to progress
+				_, _ = controllerReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: uniqueNamespacedName,
+				})
 				return updatedPackageBundle.Status.Phase
 			}, time.Second*10, time.Millisecond*100).Should(Equal(orchestrationciscocomv1alpha1.PackageBundlePhaseDownloaded))
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, uniquePB)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, completedJob)).To(Succeed())
 		})
 
 		It("should handle Job failure correctly", func() {
@@ -254,6 +346,263 @@ var _ = Describe("PackageBundle Controller", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(phase).To(Equal(orchestrationciscocomv1alpha1.PackageBundlePhaseFailedToDownload))
 			Expect(message).To(Equal("Job failed due to test error"))
+		})
+	})
+
+	Context("PackageBundle Finalizer and Cleanup", func() {
+		var pbReconciler *PackageBundleReconciler
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			pbReconciler = &PackageBundleReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+		})
+
+		Describe("Finalizer Management", func() {
+			It("should add finalizer to new PackageBundle", func() {
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-finalizer",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url:  "https://github.com/example/packages.git",
+							Path: "packages",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "alpine/git",
+							},
+							Build: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "nso-builder:latest",
+							},
+						},
+					},
+				}
+
+				By("Creating PackageBundle without finalizer")
+				err := k8sClient.Create(ctx, testPB)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Reconciling to add finalizer")
+				_, err = pbReconciler.Reconcile(ctx, reconcile.Request{
+					NamespacedName: types.NamespacedName{
+						Name:      testPB.Name,
+						Namespace: testPB.Namespace,
+					},
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Checking finalizer was added")
+				updatedPB := &orchestrationciscocomv1alpha1.PackageBundle{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      testPB.Name,
+					Namespace: testPB.Namespace,
+				}, updatedPB)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedPB.Finalizers).To(ContainElement("packagebundle.orchestration.cisco.com/finalizer"))
+
+				// Cleanup
+				err = k8sClient.Delete(ctx, testPB)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		Describe("unmountPVCFromNSO", func() {
+			It("should remove PVC volume from NSO when PackageBundle is deleted", func() {
+				// Create test NSO with mounted PVC
+				testNSO := &orchestrationciscocomv1alpha1.NSO{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-nso-cleanup",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.NSOSpec{
+						Image:       "nso:latest",
+						ServiceName: "test-nso-svc",
+						LabelSelector: map[string]string{
+							"app": "nso-test-cleanup",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name: "http",
+								Port: 8080,
+							},
+						},
+						AdminCredentials: orchestrationciscocomv1alpha1.Credentials{
+							Username:          "admin",
+							PasswordSecretRef: "admin-secret",
+						},
+						Volumes: []corev1.Volume{
+							{
+								Name: "package-test-cleanup-pb",
+								VolumeSource: corev1.VolumeSource{
+									PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "test-pvc",
+									},
+								},
+							},
+						},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      "package-test-cleanup-pb",
+								MountPath: "/nso/run/packages",
+							},
+						},
+					},
+				}
+
+				err := k8sClient.Create(ctx, testNSO)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Create PackageBundle
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cleanup-pb",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso-cleanup",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url:  "https://github.com/example/packages.git",
+							Path: "packages",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "alpine/git",
+							},
+							Build: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "nso-builder:latest",
+							},
+						},
+					},
+				}
+
+				By("Calling unmountPVCFromNSO")
+				err = pbReconciler.unmountPVCFromNSO(ctx, testPB)
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying volume was removed from NSO")
+				updatedNSO := &orchestrationciscocomv1alpha1.NSO{}
+				err = k8sClient.Get(ctx, types.NamespacedName{
+					Name:      testNSO.Name,
+					Namespace: testNSO.Namespace,
+				}, updatedNSO)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Check volume was removed
+				volumeFound := false
+				for _, vol := range updatedNSO.Spec.Volumes {
+					if vol.Name == "package-test-cleanup-pb" {
+						volumeFound = true
+						break
+					}
+				}
+				Expect(volumeFound).To(BeFalse(), "Volume should be removed from NSO")
+
+				// Check volume mount was removed
+				mountFound := false
+				for _, mount := range updatedNSO.Spec.VolumeMounts {
+					if mount.Name == "package-test-cleanup-pb" {
+						mountFound = true
+						break
+					}
+				}
+				Expect(mountFound).To(BeFalse(), "Volume mount should be removed from NSO")
+
+				// Cleanup
+				err = k8sClient.Delete(ctx, testNSO)
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			It("should handle gracefully when NSO does not exist", func() {
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-no-nso",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "nonexistent-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url: "https://github.com/example/packages.git",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{Image: "alpine/git"},
+							Build:    orchestrationciscocomv1alpha1.ContainerParams{Image: "nso:latest"},
+						},
+					},
+				}
+
+				By("Calling unmountPVCFromNSO with nonexistent NSO")
+				err := pbReconciler.unmountPVCFromNSO(ctx, testPB)
+				Expect(err).NotTo(HaveOccurred(), "Should not error when NSO doesn't exist")
+			})
+
+			It("should handle gracefully when volume is not mounted", func() {
+				// Create NSO without the package volume
+				testNSO := &orchestrationciscocomv1alpha1.NSO{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-nso-no-volume",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.NSOSpec{
+						Image:       "nso:latest",
+						ServiceName: "test-nso-svc",
+						LabelSelector: map[string]string{
+							"app": "nso-test",
+						},
+						Ports: []corev1.ServicePort{
+							{
+								Name: "http",
+								Port: 8080,
+							},
+						},
+						AdminCredentials: orchestrationciscocomv1alpha1.Credentials{
+							Username:          "admin",
+							PasswordSecretRef: "admin-secret",
+						},
+					},
+				}
+
+				err := k8sClient.Create(ctx, testNSO)
+				Expect(err).NotTo(HaveOccurred())
+
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-no-mount",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso-no-volume",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url: "https://github.com/example/packages.git",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{Image: "alpine/git"},
+							Build:    orchestrationciscocomv1alpha1.ContainerParams{Image: "nso:latest"},
+						},
+					},
+				}
+
+				By("Calling unmountPVCFromNSO when volume is not mounted")
+				err = pbReconciler.unmountPVCFromNSO(ctx, testPB)
+				Expect(err).NotTo(HaveOccurred(), "Should not error when volume is not mounted")
+
+				// Cleanup
+				err = k8sClient.Delete(ctx, testNSO)
+				Expect(err).NotTo(HaveOccurred())
+			})
 		})
 	})
 })

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -228,6 +228,15 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 		},
 	}
 
+	if pb.Spec.Credentials.SshKeySecretRef != "" {
+		securityContext = &corev1.SecurityContext{
+			AllowPrivilegeEscalation: ptr.To(false),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		}
+	}
+
 	resources := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("100m"),
@@ -237,6 +246,68 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 			corev1.ResourceCPU:    resource.MustParse("1"),
 			corev1.ResourceMemory: resource.MustParse("1Gi"),
 		},
+	}
+
+	gitCloneCmd := []string{"git", "clone", "--depth", "1"}
+	if pb.Spec.Source.Branch != "" {
+		gitCloneCmd = append(gitCloneCmd, "--branch", pb.Spec.Source.Branch)
+	}
+	gitCloneCmd = append(gitCloneCmd, pb.Spec.Source.Url, volumeMountPath)
+
+
+	initVolumeMounts := []corev1.VolumeMount{{
+		Name:      volumeName,
+		MountPath: volumeMountPath,
+	}}
+
+	volumes := []corev1.Volume{{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: pvcName,
+			},
+		},
+	}}
+
+	var initEnv []corev1.EnvVar
+	var podSecurityContext *corev1.PodSecurityContext
+	if pb.Spec.Credentials.SshKeySecretRef != "" {
+		sshKeyMode := int32(0400) 
+		sshVolumeName := "ssh-key"
+		sshKeyPath := "/.ssh"
+
+		volumes = append(volumes, corev1.Volume{
+			Name: sshVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName:  pb.Spec.Credentials.SshKeySecretRef,
+					DefaultMode: &sshKeyMode,
+					Items: []corev1.KeyToPath{{
+						Key:  "id_rsa",
+						Path: "id_rsa",
+						Mode: &sshKeyMode,
+					}},
+				},
+			},
+		})
+		initVolumeMounts = append(initVolumeMounts, corev1.VolumeMount{
+			Name:      sshVolumeName,
+			MountPath: sshKeyPath,
+			ReadOnly:  true,
+		})
+
+		initEnv = []corev1.EnvVar{
+			{
+				Name:  "HOME",
+				Value: "/tmp",  
+			},
+			{
+				Name:  "GIT_SSH_COMMAND",
+				Value: fmt.Sprintf("ssh -i %s/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null", sshKeyPath),
+			},
+		}
+
+		podSecurityContext = nil
 	}
 
 	job := &batchv1.Job{
@@ -249,19 +320,18 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 			BackoffLimit:            &backoffLimit,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy: corev1.RestartPolicyNever,
+					RestartPolicy:      corev1.RestartPolicyNever,
+					SecurityContext:    podSecurityContext,
 					InitContainers: []corev1.Container{{
-						Name:            fmt.Sprintf("%s-downloader", pb.Name),
-						Image:           pb.Spec.Config.Download.Image,
-						ImagePullPolicy: corev1.PullIfNotPresent,
-						Command:         []string{"git", "clone", "--depth", "1", pb.Spec.Source.Url, volumeMountPath},
-						Resources:       resources,
-						SecurityContext: securityContext,
-						VolumeMounts: []corev1.VolumeMount{{
-							Name:      volumeName,
-							MountPath: volumeMountPath,
-						}},
-					}},
+					Name:            fmt.Sprintf("%s-downloader", pb.Name),
+					Image:           pb.Spec.Config.Download.Image,
+					ImagePullPolicy: corev1.PullIfNotPresent,
+					Command:         gitCloneCmd,
+					Env:             initEnv,
+					Resources:       resources,
+					SecurityContext: securityContext,
+					VolumeMounts:    initVolumeMounts,
+				}},
 					Containers: []corev1.Container{{
 						Name:       fmt.Sprintf("%s-builder", pb.Name),
 						Image:      pb.Spec.Config.Build.Image,
@@ -274,14 +344,7 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 							MountPath: volumeMountPath,
 						}},
 					}},
-					Volumes: []corev1.Volume{{
-						Name: volumeName,
-						VolumeSource: corev1.VolumeSource{
-							PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-								ClaimName: pvcName,
-							},
-						},
-					}},
+					Volumes: volumes,
 				},
 			},
 		},

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -223,7 +223,7 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 	volumeName := jobVolumeName
 	volumeMountPath := jobVolumeMountPath
 	packagesPath := normalizePathString(pb.Spec.Source.Path)
-	var ttlSecondsAfterFinished int32 = 300
+	var ttlSecondsAfterFinished int32 = 1800
 	var backoffLimit int32 = 3
 
 	// Determine if we're using SSH (git@ URL) vs HTTPS

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -33,6 +33,12 @@ import (
 	nsov1alpha1 "github.com/carlosgrillet/nso-operator/api/v1alpha1"
 )
 
+const (
+	sshKeyFileMode  = int32(0400)
+	sshVolumeName   = "ssh-key"
+	sshKeyMountPath = "/.ssh"
+)
+
 func (r *NSOReconciler) newCDBPersistentVolumeClaim(ctx context.Context, nso *nsov1alpha1.NSO) *corev1.PersistentVolumeClaim {
 	log := logf.FromContext(ctx)
 	defaultSize := "5Gi"
@@ -258,7 +264,6 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 	}
 	gitCloneCmd = append(gitCloneCmd, pb.Spec.Source.Url, volumeMountPath)
 
-
 	initVolumeMounts := []corev1.VolumeMount{{
 		Name:      volumeName,
 		MountPath: volumeMountPath,
@@ -275,41 +280,37 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 
 	var initEnv []corev1.EnvVar
 	var podSecurityContext *corev1.PodSecurityContext
-	
+
 	// Only mount SSH key if using SSH protocol (git@)
 	if isSSH && pb.Spec.Credentials.SshKeySecretRef != "" {
-		sshKeyMode := int32(0400) 
-		sshVolumeName := "ssh-key"
-		sshKeyPath := "/.ssh"
-
 		volumes = append(volumes, corev1.Volume{
 			Name: sshVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName:  pb.Spec.Credentials.SshKeySecretRef,
-					DefaultMode: &sshKeyMode,
+					DefaultMode: ptr.To(sshKeyFileMode),
 					Items: []corev1.KeyToPath{{
 						Key:  "id_rsa",
 						Path: "id_rsa",
-						Mode: &sshKeyMode,
+						Mode: ptr.To(sshKeyFileMode),
 					}},
 				},
 			},
 		})
 		initVolumeMounts = append(initVolumeMounts, corev1.VolumeMount{
 			Name:      sshVolumeName,
-			MountPath: sshKeyPath,
+			MountPath: sshKeyMountPath,
 			ReadOnly:  true,
 		})
 
 		initEnv = []corev1.EnvVar{
 			{
 				Name:  "HOME",
-				Value: "/tmp",  
+				Value: "/tmp",
 			},
 			{
 				Name:  "GIT_SSH_COMMAND",
-				Value: fmt.Sprintf("ssh -i %s/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null", sshKeyPath),
+				Value: fmt.Sprintf("ssh -i %s/id_rsa -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null", sshKeyMountPath),
 			},
 		}
 
@@ -326,18 +327,18 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 			BackoffLimit:            &backoffLimit,
 			Template: corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					SecurityContext:    podSecurityContext,
+					RestartPolicy:   corev1.RestartPolicyNever,
+					SecurityContext: podSecurityContext,
 					InitContainers: []corev1.Container{{
-					Name:            fmt.Sprintf("%s-downloader", pb.Name),
-					Image:           pb.Spec.Config.Download.Image,
-					ImagePullPolicy: corev1.PullIfNotPresent,
-					Command:         gitCloneCmd,
-					Env:             initEnv,
-					Resources:       resources,
-					SecurityContext: securityContext,
-					VolumeMounts:    initVolumeMounts,
-				}},
+						Name:            fmt.Sprintf("%s-downloader", pb.Name),
+						Image:           pb.Spec.Config.Download.Image,
+						ImagePullPolicy: corev1.PullIfNotPresent,
+						Command:         gitCloneCmd,
+						Env:             initEnv,
+						Resources:       resources,
+						SecurityContext: securityContext,
+						VolumeMounts:    initVolumeMounts,
+					}},
 					Containers: []corev1.Container{{
 						Name:       fmt.Sprintf("%s-builder", pb.Name),
 						Image:      pb.Spec.Config.Build.Image,

--- a/internal/controller/resources.go
+++ b/internal/controller/resources.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
@@ -219,6 +220,9 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 	var ttlSecondsAfterFinished int32 = 300
 	var backoffLimit int32 = 3
 
+	// Determine if we're using SSH (git@ URL) vs HTTPS
+	isSSH := strings.HasPrefix(pb.Spec.Source.Url, "git@")
+
 	securityContext := &corev1.SecurityContext{
 		RunAsNonRoot:             ptr.To(true),
 		RunAsUser:                ptr.To(int64(1000)),
@@ -228,7 +232,7 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 		},
 	}
 
-	if pb.Spec.Credentials.SshKeySecretRef != "" {
+	if isSSH {
 		securityContext = &corev1.SecurityContext{
 			AllowPrivilegeEscalation: ptr.To(false),
 			Capabilities: &corev1.Capabilities{
@@ -271,7 +275,9 @@ func (r *PackageBundleReconciler) newJob(ctx context.Context, pb *nsov1alpha1.Pa
 
 	var initEnv []corev1.EnvVar
 	var podSecurityContext *corev1.PodSecurityContext
-	if pb.Spec.Credentials.SshKeySecretRef != "" {
+	
+	// Only mount SSH key if using SSH protocol (git@)
+	if isSSH && pb.Spec.Credentials.SshKeySecretRef != "" {
 		sshKeyMode := int32(0400) 
 		sshVolumeName := "ssh-key"
 		sshKeyPath := "/.ssh"

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Resource Creation Functions", func() {
 
 		Describe("newStatefulSet", func() {
 			It("should create a statefulset with correct specifications", func() {
-				// Create a separate NSO for this test
+
 				testNSO2 := &orchestrationciscocomv1alpha1.NSO{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "test-nso-statefulset",
@@ -436,7 +436,7 @@ var _ = Describe("Resource Creation Functions", func() {
 				initContainer := initContainers[0]
 				Expect(initContainer.Name).To(Equal("test-pb-resources-downloader"))
 				Expect(initContainer.Image).To(Equal("alpine/git"))
-				Expect(initContainer.Command).To(Equal([]string{"git", "clone", "--depth", "1", "https://github.com/example/test-repo.git", "/repo"}))
+				Expect(initContainer.Command).To(Equal([]string{"git", "clone", "--depth", "1", "--branch", "main", "https://github.com/example/test-repo.git", "/repo"}))
 
 				// Check init container volume mounts
 				initVolumeMounts := initContainer.VolumeMounts
@@ -558,6 +558,339 @@ var _ = Describe("Resource Creation Functions", func() {
 			It("should handle just slashes", func() {
 				result := normalizePathString("///")
 				Expect(result).To(Equal(""))
+			})
+		})
+	})
+
+	Context("PackageBundle Job Creation with Git Features", func() {
+		var pbReconciler *PackageBundleReconciler
+		ctx := context.Background()
+
+		BeforeEach(func() {
+			pbReconciler = &PackageBundleReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+		})
+
+		Describe("newJob with Git Branch Support", func() {
+			It("should include branch in git clone command when branch is specified", func() {
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-branch",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url:    "https://github.com/example/packages.git",
+							Branch: "develop",
+							Path:   "packages",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "alpine/git",
+							},
+							Build: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "nso-builder:latest",
+							},
+						},
+					},
+				}
+
+				job := pbReconciler.newJob(ctx, testPB)
+
+				// Check that git clone command includes --branch flag
+				initContainer := job.Spec.Template.Spec.InitContainers[0]
+				Expect(initContainer.Command).To(ContainElement("--branch"))
+				Expect(initContainer.Command).To(ContainElement("develop"))
+
+				// Verify command structure: git clone --depth 1 --branch develop <url> <path>
+				cmdIndex := 0
+				for i, arg := range initContainer.Command {
+					if arg == "git" {
+						cmdIndex = i
+						break
+					}
+				}
+				Expect(initContainer.Command[cmdIndex]).To(Equal("git"))
+				Expect(initContainer.Command[cmdIndex+1]).To(Equal("clone"))
+				Expect(initContainer.Command).To(ContainElement("--depth"))
+				Expect(initContainer.Command).To(ContainElement("1"))
+			})
+
+			It("should not include branch flag when branch is empty", func() {
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-no-branch",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url:  "https://github.com/example/packages.git",
+							Path: "packages",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "alpine/git",
+							},
+							Build: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "nso-builder:latest",
+							},
+						},
+					},
+				}
+
+				job := pbReconciler.newJob(ctx, testPB)
+
+				// Check that git clone command does NOT include --branch flag
+				initContainer := job.Spec.Template.Spec.InitContainers[0]
+				Expect(initContainer.Command).NotTo(ContainElement("--branch"))
+			})
+		})
+
+		Describe("newJob with SSH Authentication", func() {
+			It("should mount SSH key and configure environment for git@ URLs", func() {
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-ssh",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Credentials: orchestrationciscocomv1alpha1.AccessCredentials{
+							SshKeySecretRef: "ssh-key-secret",
+						},
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url:  "git@github.com:example/packages.git",
+							Path: "packages",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "alpine/git",
+							},
+							Build: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "nso-builder:latest",
+							},
+						},
+					},
+				}
+
+				job := pbReconciler.newJob(ctx, testPB)
+
+				// Check SSH key volume is mounted
+				volumes := job.Spec.Template.Spec.Volumes
+				sshVolumeFound := false
+				for _, vol := range volumes {
+					if vol.Name == sshVolumeName {
+						sshVolumeFound = true
+						Expect(vol.Secret).NotTo(BeNil())
+						Expect(vol.Secret.SecretName).To(Equal("ssh-key-secret"))
+						break
+					}
+				}
+				Expect(sshVolumeFound).To(BeTrue(), "SSH key volume should be present")
+
+				// Check SSH key volume mount in init container
+				initContainer := job.Spec.Template.Spec.InitContainers[0]
+				sshMountFound := false
+				for _, mount := range initContainer.VolumeMounts {
+					if mount.Name == sshVolumeName {
+						sshMountFound = true
+						Expect(mount.MountPath).To(Equal("/.ssh"))
+						Expect(mount.ReadOnly).To(BeTrue())
+						break
+					}
+				}
+				Expect(sshMountFound).To(BeTrue(), "SSH key mount should be present in init container")
+
+				// Check environment variables for SSH
+				homeEnvFound := false
+				gitSSHEnvFound := false
+				for _, env := range initContainer.Env {
+					if env.Name == "HOME" {
+						homeEnvFound = true
+						Expect(env.Value).To(Equal("/tmp"))
+					}
+					if env.Name == "GIT_SSH_COMMAND" {
+						gitSSHEnvFound = true
+						Expect(env.Value).To(ContainSubstring("ssh -i /.ssh/id_rsa"))
+						Expect(env.Value).To(ContainSubstring("StrictHostKeyChecking=no"))
+					}
+				}
+				Expect(homeEnvFound).To(BeTrue(), "HOME environment variable should be set")
+				Expect(gitSSHEnvFound).To(BeTrue(), "GIT_SSH_COMMAND environment variable should be set")
+			})
+
+			It("should NOT mount SSH key for HTTPS URLs even if sshKeySecretRef is set", func() {
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-https-no-ssh",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Credentials: orchestrationciscocomv1alpha1.AccessCredentials{
+							SshKeySecretRef: "ssh-key-secret",
+						},
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url:  "https://github.com/example/packages.git",
+							Path: "packages",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "alpine/git",
+							},
+							Build: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "nso-builder:latest",
+							},
+						},
+					},
+				}
+
+				job := pbReconciler.newJob(ctx, testPB)
+
+				// Check SSH key volume is NOT mounted
+				volumes := job.Spec.Template.Spec.Volumes
+				for _, vol := range volumes {
+					Expect(vol.Name).NotTo(Equal(sshVolumeName), "SSH key volume should NOT be present for HTTPS URLs")
+				}
+
+				// Check init container has no SSH environment variables
+				initContainer := job.Spec.Template.Spec.InitContainers[0]
+				for _, env := range initContainer.Env {
+					Expect(env.Name).NotTo(Equal("GIT_SSH_COMMAND"), "GIT_SSH_COMMAND should NOT be set for HTTPS URLs")
+				}
+
+				// Check security context is standard (RunAsUser=1000)
+				Expect(initContainer.SecurityContext).NotTo(BeNil())
+				Expect(initContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+				Expect(*initContainer.SecurityContext.RunAsUser).To(Equal(int64(1000)))
+			})
+
+			It("should use different security context for SSH vs HTTPS", func() {
+				// SSH URL test
+				sshPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-ssh", Namespace: "default"},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Credentials: orchestrationciscocomv1alpha1.AccessCredentials{
+							SshKeySecretRef: "ssh-key",
+						},
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url: "git@github.com:example/repo.git",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{Image: "alpine/git"},
+							Build:    orchestrationciscocomv1alpha1.ContainerParams{Image: "nso:latest"},
+						},
+					},
+				}
+
+				sshJob := pbReconciler.newJob(ctx, sshPB)
+				sshInitContainer := sshJob.Spec.Template.Spec.InitContainers[0]
+
+				// SSH should NOT have RunAsUser set (runs as default container user)
+				if sshInitContainer.SecurityContext != nil {
+					Expect(sshInitContainer.SecurityContext.RunAsUser).To(BeNil())
+				}
+
+				// HTTPS URL test
+				httpsPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-https", Namespace: "default"},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url: "https://github.com/example/repo.git",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{Image: "alpine/git"},
+							Build:    orchestrationciscocomv1alpha1.ContainerParams{Image: "nso:latest"},
+						},
+					},
+				}
+
+				httpsJob := pbReconciler.newJob(ctx, httpsPB)
+				httpsInitContainer := httpsJob.Spec.Template.Spec.InitContainers[0]
+
+				// HTTPS should have RunAsUser=1000
+				Expect(httpsInitContainer.SecurityContext).NotTo(BeNil())
+				Expect(httpsInitContainer.SecurityContext.RunAsUser).NotTo(BeNil())
+				Expect(*httpsInitContainer.SecurityContext.RunAsUser).To(Equal(int64(1000)))
+			})
+		})
+
+		Describe("newJob with combined SSH and Branch", func() {
+			It("should support both SSH authentication and branch selection", func() {
+				testPB := &orchestrationciscocomv1alpha1.PackageBundle{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pb-ssh-branch",
+						Namespace: "default",
+					},
+					Spec: orchestrationciscocomv1alpha1.PackageBundleSpec{
+						TargetName:  "test-nso",
+						StorageSize: "1Gi",
+						Origin:      orchestrationciscocomv1alpha1.OriginTypeSCM,
+						Credentials: orchestrationciscocomv1alpha1.AccessCredentials{
+							SshKeySecretRef: "ssh-key-secret",
+						},
+						Source: orchestrationciscocomv1alpha1.PackageSource{
+							Url:    "git@github.com:example/packages.git",
+							Branch: "feature/new-packages",
+							Path:   "packages",
+						},
+						Config: orchestrationciscocomv1alpha1.PackageConfig{
+							Download: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "alpine/git",
+							},
+							Build: orchestrationciscocomv1alpha1.ContainerParams{
+								Image: "nso-builder:latest",
+							},
+						},
+					},
+				}
+
+				job := pbReconciler.newJob(ctx, testPB)
+
+				// Check both SSH and branch are configured
+				initContainer := job.Spec.Template.Spec.InitContainers[0]
+
+				// Branch in command
+				Expect(initContainer.Command).To(ContainElement("--branch"))
+				Expect(initContainer.Command).To(ContainElement("feature/new-packages"))
+
+				// SSH environment variables
+				gitSSHEnvFound := false
+				for _, env := range initContainer.Env {
+					if env.Name == "GIT_SSH_COMMAND" {
+						gitSSHEnvFound = true
+						break
+					}
+				}
+				Expect(gitSSHEnvFound).To(BeTrue())
+
+				// SSH volume mount
+				sshMountFound := false
+				for _, mount := range initContainer.VolumeMounts {
+					if mount.Name == sshVolumeName && mount.MountPath == "/.ssh" {
+						sshMountFound = true
+						break
+					}
+				}
+				Expect(sshMountFound).To(BeTrue())
 			})
 		})
 	})

--- a/internal/controller/resources_test.go
+++ b/internal/controller/resources_test.go
@@ -422,7 +422,7 @@ var _ = Describe("Resource Creation Functions", func() {
 				Expect(job.Namespace).To(Equal("default"))
 
 				// Check job specifications
-				Expect(*job.Spec.TTLSecondsAfterFinished).To(Equal(int32(300)))
+				Expect(*job.Spec.TTLSecondsAfterFinished).To(Equal(int32(1800)))
 				Expect(*job.Spec.BackoffLimit).To(Equal(int32(3)))
 
 				// Check pod template


### PR DESCRIPTION
# ✨ Summary
This PR enhances the **PackageBundle controller** with three major features to improve **Git repository integration** and **resource management**.  

---

# 📝 PR Type
- [x] Enhancement  
- [ ] Bug Fix  
- [ ] Documentation  
- [ ] Refactor  
- [ ] Other (please specify)  

---

# 🆕 Features Added

### 1️⃣ SSH Key Authentication for Git Cloning
- 🔑 Support for SSH-based Git authentication via `.spec.credentials.sshKeySecretRef`  
- 🗝️ SSH key securely mounted from a Kubernetes Secret at `/.ssh/id_rsa` with `0400` permissions  
- ⚙️ Configures `GIT_SSH_COMMAND` to **disable strict host key checking** for automation  
- 🔄 Only applies SSH configuration when URL starts with `git@` (HTTPS URLs remain unchanged)  
- 📄 Example SSH key secret in `config/samples/ssh-key-secret-sample.yaml`  

---

### 2️⃣ Git Branch Selection
- 🌿 Added `.spec.source.branch` field to PackageBundle CRD  
- 📂 Supports downloading packages from **specific Git branches**  
- 🛠️ Adds `--branch` flag to `git clone` command when branch is specified  
- 🔀 Enables managing packages across multiple branches (e.g., develop, staging, production)  

---

### 3️⃣ PVC Cleanup Finalizer
- 🧹 Implements finalizer pattern to ensure **clean PVC unmounting before deletion**  
- 🚫 Prevents stuck PVCs that block PackageBundle deletion  
- 🔌 Automatically removes PVC volume mounts from NSO StatefulSet when PackageBundle is deleted  
- 🔁 Uses retry logic to handle conflicts during NSO updates  

---

# 🛠 Technical Details

**Files Modified:**  
- `api/v1alpha1/packagebundle_types.go` – Added `Branch` and `SshKeySecretRef` fields  
- `internal/controller/resources.go` – SSH key mounting & branch logic in Job creation  
- `internal/controller/packagebundle_controller.go` – Finalizer implementation for PVC cleanup  
- `config/samples/` – Added SSH key secret sample, updated PackageBundle sample  

**Constants Added:**  
- `sshKeyFileMode = 0400` – Secure file permissions for SSH keys  
- `sshVolumeName = "ssh-key"` – Volume name for SSH key mount  
- `sshKeyMountPath = "/.ssh"` – Mount path for SSH keys  

**Job TTL:**  
- Increased `TTLSecondsAfterFinished` to `1800` seconds (30 minutes) for better debugging visibility  

---

# ✅ Testing
- Added **39 comprehensive unit tests** covering all new features  
- Tests verify SSH key mounting for `git@` URLs  
- Tests verify branch flag in `git clone` commands  
- Tests verify HTTPS URLs don't get SSH configuration  
- Tests verify PVC cleanup during PackageBundle deletion  
- All tests passing with **49.5% code coverage**  

---

# 🔒 Security Considerations
- SSH keys mounted with restrictive `0400` permissions (read-only by owner)  
- SSH key logic only applies to **SSH URLs (`git@`)**, not HTTPS  
- No hardcoded credentials in code or samples  
- Sample secret file contains **placeholder only**, with instructions for users  

---

# Testing SSH Authentication for PackageBundle

## Prerequisites
- Kubernetes cluster running
- NSO operator deployed
- Access to a private Git repository (GitHub, GitLab, Bitbucket, etc.)

## Step 1: Generate SSH Key Pair

# Generate a new SSH key (PEM format required)
ssh-keygen -t rsa -b 4096 -m PEM -f ~/.ssh/nso-operator-test -N ""

# This creates two files:
- ~/.ssh/nso-operator-test (private key - keep secret!)
-  - ~/.ssh/nso-operator-test.pub (public key - add to Git provider)## Step 2: Add Public Key to Git Provider

### For GitHub:
1. Copy public key: `cat ~/.ssh/nso-operator-test.pub`
2. Go to: Settings → SSH and GPG keys → New SSH key
3. Paste the public key and save

### For GitLab:
1. Copy public key: `cat ~/.ssh/nso-operator-test.pub`
2. Go to: Preferences → SSH Keys → Add new key
3. Paste the public key and save

## Step 3: Create Kubernetes Secret

# Create secret from private key
kubectl create secret generic ssh-key \
  --from-file=id_rsa=$HOME/.ssh/nso-operator-test \
  --namespace=default**Verify the secret:**
kubectl get secret ssh-key -o yaml## Step 4: Create PackageBundle with SSH

Create a file `packagebundle-ssh-test.yaml`:

apiVersion: orchestration.cisco.com/v1alpha1
kind: PackageBundle
metadata:
  name: ssh-test-packages
  namespace: default
spec:
  targetName: nso-sample  # Your NSO instance name
  storageSize: 2Gi
  origin: SCM
  credentials:
    sshKeySecretRef: ssh-key  # Reference to secret created above
  source:
    url: git@github.com:your-org/your-private-repo.git  # SSH URL format
    branch: main  # Optional: specify branch
    path: packages  # Path to NSO packages in repo
  config:
    download:
      image: alpine/git
    build:
      image: containers.cisco.com/cisco-nso/cisco-nso-prod:6.1.11


## Step 5: Apply and Monitor

# Apply the PackageBundle
kubectl apply -f packagebundle-ssh-test.yaml

# Watch the job creation (stays visible for 30 minutes)
kubectl get jobs -w

# Check PackageBundle status
kubectl get packagebundle ssh-test-packages -o yaml

# View job logs to see SSH connection
kubectl logs job/download-ssh-test-packages -c ssh-test-packages-downloader

# Check if packages were loaded into NSO
kubectl exec -it nso-sample-0 -- ls -la /nso/run/packages/## Expected Behavior

1. **Job Creation:** A job named `download-ssh-test-packages` is created
2. **SSH Connection:** Job uses SSH key to authenticate (no password prompt)
3. **Git Clone:** Clones from specified branch using `git clone --depth 1 --branch <branch> git@...`
4. **Package Build:** Builds NSO packages using `make clean all`
5. **Status Progression:** Pending → ContainerCreating → Downloading → Downloaded → Loading → Loaded
6. **Job Cleanup:** Job remains visible for 30 minutes after completion

## Troubleshooting

### "Permission denied (publickey)"
- Check that public key is added to Git provider
- Verify private key is in PEM format (not OpenSSH format)
- Convert if needed: `ssh-keygen -p -m PEM -f ~/.ssh/id_rsa`

### "No user exists for uid 1000"
- This is expected when using SSH - the operator handles this automatically
- The SSH key is mounted at `/.ssh/id_rsa` with proper permissions

### Job not appearing
- Check operator logs: `kubectl logs -n nso-operator-system deployment/nso-operator-controller-manager`
- Verify secret exists: `kubectl get secret ssh-key`
- Check PackageBundle status: `kubectl describe packagebundle ssh-test-packages`

## Requirements for SSH Authentication

The CRD requires:
- `.spec.credentials.sshKeySecretRef` - Name of the Kubernetes Secret containing the SSH private key
- `.spec.source.url` - Valid SSH URL format (must start with `git@`)

For HTTPS repositories, omit `sshKeySecretRef` and use `https://` URL format instead.

## Security Notes

- Private keys have `0400` permissions (read-only by owner)
- SSH strict host key checking

